### PR TITLE
Fix bloom filter probe using all columns instead of per-column lookup

### DIFF
--- a/src/operators/physical_use_bf.cpp
+++ b/src/operators/physical_use_bf.cpp
@@ -160,7 +160,7 @@ OperatorResultType PhysicalUseBF::ExecuteInternal(ExecutionContext &context, Dat
 		// }
 
 		// lookup directly into selection vector
-		result_count = bf->LookupSel(input, sel, bound_column_indices, bf_state.bit_vector.data());
+		result_count = bf->LookupSel(input, sel, {bound_column_indices[i]}, bf_state.bit_vector.data());
 
 		// early exit if no rows passed
 		if (result_count == 0) {


### PR DESCRIPTION
LookupSel was called with the full bound_column_indices vector, hashing all columns together. But Insert in CreateBF inserts one column at a time via {bound_column_indices[i]}. This mismatch causes hash(single column) != hash(all columns), resulting in false negatives and incorrect query results on any multi-column join.

Fix: probe each bloom filter with only its corresponding column index, matching how Insert was called.