### PR TITLE
Clear probe columns when merging create filters

### DIFF
--- a/src/optimizer/robust_optimizer.cpp
+++ b/src/optimizer/robust_optimizer.cpp
@@ -1199,6 +1199,7 @@ RobustOptimizerContextState::BuildStackedBFOperators(unique_ptr<LogicalOperator>
 				// multiple consecutive CREATEs for same table - merge them
 				FilterOperation merged_op = consecutive_creates[0];
 				merged_op.build_columns.clear();
+				merged_op.probe_columns.clear();
 
 				// collect all build columns
 				for (const auto &op : consecutive_creates) {


### PR DESCRIPTION
When merging consecutive CREATEs, `probe_columns` was not cleared, which could leave old probe columns in the merged operator.

This PR clears `probe_columns` during the merge.