### PR TITLE
Avoid lifting CREATE_FILTERs across binding-changing operators

### DIFF
--- a/src/optimizer/robust_optimizer.cpp
+++ b/src/optimizer/robust_optimizer.cpp
@@ -1571,12 +1571,15 @@ void RobustOptimizerContextState::SetupDynamicFilterPushdown(LogicalOperator *pl
 static LogicalOperator *FindDeepestCreateFilter(LogicalOperator *node) {
 	LogicalOperator *deepest = nullptr;
 	while (node) {
+		if (node->children.empty()) {
+			break;
+		}
+		if (node->children.size() != 1 || node->GetColumnBindings() != node->children[0]->GetColumnBindings()) {
+			break;
+		}
 		if (node->type == LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR &&
 		    dynamic_cast<LogicalCreateFilter *>(node)) {
 			deepest = node;
-		}
-		if (node->children.empty()) {
-			break;
 		}
 		node = node->children[0].get();
 	}


### PR DESCRIPTION
`CREATE_FILTER` lifting could go across operators that change column bindings. This caused the `LOGICAL_FILTER` projection map to no longer match the column bindings of the deeper `LOGICAL_GET`, resulting in binding errors.

This PR stops `CREATE_FILTER` lifting when the column bindings change.