### PR TITLE
Detect-and-bail guard for the `join_order` heuristic in cyclic join queries

### DIFF
--- a/src/optimizer/robust_optimizer.cpp
+++ b/src/optimizer/robust_optimizer.cpp
@@ -796,6 +796,42 @@ vector<PhysicalDAGNode *> RobustOptimizerContextState::BuildPhysicalPlanDAG(Logi
 	return all_nodes;
 }
 
+bool ExistCycle(vector<PhysicalDAGNode *> &all_nodes) {
+	unordered_map<idx_t, bool> visited;
+	for (auto *node : all_nodes) {
+		if (visited.count(node->table_idx)) {
+			continue;
+		}
+		idx_t cntNodes = 0;
+		idx_t cntEdges = 0;
+		vector<PhysicalDAGNode *> que;
+		auto discover = [&](PhysicalDAGNode *candidate) {
+			if (visited.count(candidate->table_idx)) {
+				return;
+			}
+			visited[candidate->table_idx] = true;
+			que.push_back(candidate);
+			cntNodes++;
+			cntEdges += candidate->parents.size() + candidate->children.size();
+		};
+		discover(node);
+		while (!que.empty()) {
+			auto cur = que.back();
+			que.pop_back();
+			for (auto &child : cur->children) {
+				discover(child);
+			}
+			for (auto &parent : cur->parents) {
+				discover(parent);
+			}
+		}
+		if (cntEdges / 2 >= cntNodes) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void RobustOptimizerContextState::FlipRootsToLeaves(vector<PhysicalDAGNode *> &all_nodes) {
 	// step 1: find all roots
 	vector<PhysicalDAGNode *> roots;
@@ -1679,6 +1715,10 @@ unique_ptr<LogicalOperator> RobustOptimizerContextState::Optimize(unique_ptr<Log
 		map<ColKey, ColKey> uf_parent;
 		auto all_nodes = BuildPhysicalPlanDAG(plan.get(), uf_parent);
 
+		if (ExistCycle(all_nodes)) {
+			D_PRINTF("Cycle Detected");
+			return plan;
+		}
 		// flip non-largest roots to leaves (default: on)
 		Value flip_val;
 		bool flip_roots = true;

--- a/test/sql/plan_positive.test
+++ b/test/sql/plan_positive.test
@@ -84,26 +84,7 @@ WHERE t1.k12 = t2.k12
 ----
 physical_plan	<REGEX>:.*PROBE_FILTER.*
 
-# Correctness: triangle join
-query II
-EXPLAIN SELECT count(*)
-FROM t2, t3, t4
-WHERE t2.k23 = t3.k23
-  AND t3.k34 = t4.k34
-  AND t2.k24 = t4.k24;
-----
-physical_plan	<REGEX>:.*CREATE_FILTER.*
-
-query II
-EXPLAIN SELECT count(*)
-FROM t2, t3, t4
-WHERE t2.k23 = t3.k23
-  AND t3.k34 = t4.k34
-  AND t2.k24 = t4.k24;
-----
-physical_plan	<REGEX>:.*PROBE_FILTER.*
-
-# Negative: four-table chain join
+# Positive: four-table chain join
 query II
 EXPLAIN SELECT count(*)
 FROM t1, t2, t3, t4


### PR DESCRIPTION
Cyclic join graphs can produce equivalence classes that `LogicalCreateFilter::CreatePlan` can't fully resolve, causing an out-of-bounds access in `bound_column_indices` at sink time.

This PR adds a detect-and-bail guard for the `join_order` heuristic. When a cyclic join graph is detected, the optimizer skips predicate transfer and returns the original plan.