### PR TITLE
Fix incorrect results when probing multiple bloom filters

### DIFF
--- a/src/operators/physical_probe_filter.cpp
+++ b/src/operators/physical_probe_filter.cpp
@@ -171,7 +171,8 @@ OperatorResultType PhysicalProbeFilter::ExecuteInternal(ExecutionContext &contex
 		// }
 
 		// lookup directly into selection vector
-		result_count = bf->LookupSel(input, sel, {bound_column_indices[i]}, state.bit_vector.data());
+		SelectionVector newSel = SelectionVector(input.size());
+		result_count = bf->LookupSel(input, newSel, {bound_column_indices[i]}, state.bit_vector.data());
 
 		// early exit if no rows passed
 		if (result_count == 0) {
@@ -185,7 +186,7 @@ OperatorResultType PhysicalProbeFilter::ExecuteInternal(ExecutionContext &contex
 
 		// apply filter if we filtered rows
 		if (result_count < row_num) {
-			input.Slice(sel, result_count);
+			input.Slice(newSel, result_count);
 			row_num = result_count;
 		}
 	}


### PR DESCRIPTION
When `PhysicalProbeFilter` applies multiple Bloom filters, it reuses the same selection vector for every lookup. After the first `input.Slice`, this vector is kept as the mapping from the sliced input to the original input. The next lookup produces a new selection relative to the sliced input, but writes it into the same selection vector, overwriting the previous mapping before these two selections are combined. This results in incorrect row indices and query results.

This PR uses a separate selection vector for each Bloom filter lookup.