### PR TITLE
Enable complete TPC-H Q1-Q22 benchmark coverage

### DIFF
--- a/bench_suites/tpch_baseline/q01.benchmark
+++ b/bench_suites/tpch_baseline/q01.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q01.benchmark
+# description: Run TPCH query 01 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=1
+QUERY_NUMBER_PADDED=01

--- a/bench_suites/tpch_baseline/q04.benchmark
+++ b/bench_suites/tpch_baseline/q04.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q0.benchmark
+# description: Run TPCH query 04 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=4
+QUERY_NUMBER_PADDED=04

--- a/bench_suites/tpch_baseline/q05.benchmark
+++ b/bench_suites/tpch_baseline/q05.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q05.benchmark
+# description: Run TPCH query 05 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=5
+QUERY_NUMBER_PADDED=05

--- a/bench_suites/tpch_baseline/q06.benchmark
+++ b/bench_suites/tpch_baseline/q06.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q06.benchmark
+# description: Run TPCH query 06 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=6
+QUERY_NUMBER_PADDED=06

--- a/bench_suites/tpch_baseline/q09.benchmark
+++ b/bench_suites/tpch_baseline/q09.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q09.benchmark
+# description: Run TPCH query 09 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=9
+QUERY_NUMBER_PADDED=09

--- a/bench_suites/tpch_baseline/q12.benchmark
+++ b/bench_suites/tpch_baseline/q12.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q12.benchmark
+# description: Run TPCH query 12 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=12
+QUERY_NUMBER_PADDED=12

--- a/bench_suites/tpch_baseline/q13.benchmark
+++ b/bench_suites/tpch_baseline/q13.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q13.benchmark
+# description: Run TPCH query 13 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=13
+QUERY_NUMBER_PADDED=13

--- a/bench_suites/tpch_baseline/q14.benchmark
+++ b/bench_suites/tpch_baseline/q14.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q14.benchmark
+# description: Run TPCH query 14 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=14
+QUERY_NUMBER_PADDED=14

--- a/bench_suites/tpch_baseline/q15.benchmark
+++ b/bench_suites/tpch_baseline/q15.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q15.benchmark
+# description: Run TPCH query 15 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=15
+QUERY_NUMBER_PADDED=15

--- a/bench_suites/tpch_baseline/q16.benchmark
+++ b/bench_suites/tpch_baseline/q16.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q16.benchmark
+# description: Run TPCH query 16 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=16
+QUERY_NUMBER_PADDED=16

--- a/bench_suites/tpch_baseline/q19.benchmark
+++ b/bench_suites/tpch_baseline/q19.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q19.benchmark
+# description: Run TPCH query 19 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=19
+QUERY_NUMBER_PADDED=19

--- a/bench_suites/tpch_baseline/q20.benchmark
+++ b/bench_suites/tpch_baseline/q20.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q20.benchmark
+# description: Run TPCH query 20 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=20
+QUERY_NUMBER_PADDED=20

--- a/bench_suites/tpch_baseline/q22.benchmark
+++ b/bench_suites/tpch_baseline/q22.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_baseline/q22.benchmark
+# description: Run TPCH query 22 (baseline, single-threaded)
+# group: [tpch_baseline]
+
+template benchmark/tpch_baseline/tpch_baseline.benchmark.in
+QUERY_NUMBER=22
+QUERY_NUMBER_PADDED=22

--- a/bench_suites/tpch_robust/q01.benchmark
+++ b/bench_suites/tpch_robust/q01.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q01.benchmark
+# description: Run TPCH query 01 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=1
+QUERY_NUMBER_PADDED=01

--- a/bench_suites/tpch_robust/q04.benchmark
+++ b/bench_suites/tpch_robust/q04.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q04.benchmark
+# description: Run TPCH query 04 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=4
+QUERY_NUMBER_PADDED=04

--- a/bench_suites/tpch_robust/q05.benchmark
+++ b/bench_suites/tpch_robust/q05.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q05.benchmark
+# description: Run TPCH query 05 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=5
+QUERY_NUMBER_PADDED=05

--- a/bench_suites/tpch_robust/q06.benchmark
+++ b/bench_suites/tpch_robust/q06.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q06.benchmark
+# description: Run TPCH query 06 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=6
+QUERY_NUMBER_PADDED=06

--- a/bench_suites/tpch_robust/q09.benchmark
+++ b/bench_suites/tpch_robust/q09.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q09.benchmark
+# description: Run TPCH query 09 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=9
+QUERY_NUMBER_PADDED=09

--- a/bench_suites/tpch_robust/q12.benchmark
+++ b/bench_suites/tpch_robust/q12.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q12.benchmark
+# description: Run TPCH query 12 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=12
+QUERY_NUMBER_PADDED=12

--- a/bench_suites/tpch_robust/q13.benchmark
+++ b/bench_suites/tpch_robust/q13.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q13.benchmark
+# description: Run TPCH query 13 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=13
+QUERY_NUMBER_PADDED=13

--- a/bench_suites/tpch_robust/q14.benchmark
+++ b/bench_suites/tpch_robust/q14.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q14.benchmark
+# description: Run TPCH query 14 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=14
+QUERY_NUMBER_PADDED=14

--- a/bench_suites/tpch_robust/q15.benchmark
+++ b/bench_suites/tpch_robust/q15.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q15.benchmark
+# description: Run TPCH query 15 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=15
+QUERY_NUMBER_PADDED=15

--- a/bench_suites/tpch_robust/q16.benchmark
+++ b/bench_suites/tpch_robust/q16.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q16.benchmark
+# description: Run TPCH query 16 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=16
+QUERY_NUMBER_PADDED=16

--- a/bench_suites/tpch_robust/q19.benchmark
+++ b/bench_suites/tpch_robust/q19.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q19.benchmark
+# description: Run TPCH query 19 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=19
+QUERY_NUMBER_PADDED=19

--- a/bench_suites/tpch_robust/q20.benchmark
+++ b/bench_suites/tpch_robust/q20.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q20.benchmark
+# description: Run TPCH query 20 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=20
+QUERY_NUMBER_PADDED=20

--- a/bench_suites/tpch_robust/q22.benchmark
+++ b/bench_suites/tpch_robust/q22.benchmark
@@ -1,0 +1,7 @@
+# name: benchmark/tpch_robust/q22.benchmark
+# description: Run TPCH query 22 with Robust extension (single-threaded)
+# group: [tpch_robust]
+
+template benchmark/tpch_robust/tpch_robust.benchmark.in
+QUERY_NUMBER=22
+QUERY_NUMBER_PADDED=22

--- a/scripts/bench_tpch.sh
+++ b/scripts/bench_tpch.sh
@@ -31,7 +31,7 @@ if [ -z "$(ls -A "$PROJECT_ROOT/tpchdata/queries"/q*.sql 2>/dev/null)" ]; then
 fi
 
 RUNNER="$PROJECT_ROOT/build/release/benchmark/benchmark_runner"
-PATTERN="q(02|03|07|08|10|11|17|18|21)\.benchmark"
+PATTERN="q(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22)\.benchmark"
 RUN_BASELINE=true
 RUN_ROBUST=true
 OUT_DIR="$PROJECT_ROOT/benchmark_results/tpch"


### PR DESCRIPTION
This PR adds complete TPC-H Q1-Q22 benchmark coverage. When combined with #19 , #20 , #21 , #23 , and #24 , all 22 queries execute successfully with the Robust extension and produce results consistent with baseline DuckDB.